### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled command line

### DIFF
--- a/src/VulnerableApp/src/VulnerableApp.java
+++ b/src/VulnerableApp/src/VulnerableApp.java
@@ -27,8 +27,14 @@ public class VulnerableApp extends HttpServlet {
         // Vulnerability 2: Command Injection
         try {
             String data = request.getParameter("data");
-            // Unsafe command execution
-            Runtime.getRuntime().exec("echo " + data);
+            // Validate input to allow only alphanumeric characters and spaces
+            if (data != null && data.matches("[a-zA-Z0-9 ]+")) {
+                // Safe command execution using ProcessBuilder
+                ProcessBuilder pb = new ProcessBuilder("echo", data);
+                pb.start();
+            } else {
+                response.getWriter().println("Invalid input.");
+            }
         } catch (IOException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Potential fix for [https://github.com/zhangse/bsidessf-hands-on-devsecops-2025/security/code-scanning/4](https://github.com/zhangse/bsidessf-hands-on-devsecops-2025/security/code-scanning/4)

To fix the issue, we need to prevent user-controlled input from being directly passed to `Runtime.getRuntime().exec`. The best approach is to avoid constructing commands dynamically with user input. Instead, use a safer alternative, such as hardcoding the command or validating the user input against a whitelist of allowed values. If dynamic input is unavoidable, use a library like `ProcessBuilder` to safely handle arguments.

In this case, we will:
1. Validate the `data` parameter to ensure it only contains safe, expected values (e.g., alphanumeric characters).
2. Use `ProcessBuilder` to execute the command, which allows arguments to be passed safely without concatenation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
